### PR TITLE
Extend the API to cover all use cases to grab the issuer parameter from the URL

### DIFF
--- a/Sources/THOTP/Enums/IssuerStrategy.swift
+++ b/Sources/THOTP/Enums/IssuerStrategy.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The strategy gives the freedom to decide how the `issuer` value will be grabbed from the URL.
+/// `Default` is recommended and the other options enable the API to cover all use cases by including `custom` option.
+@available(iOS 13.0, OSX 10.15, watchOS 6.0, tvOS 13.0, *)
+public enum IssuerStrategy {
+    
+    case `default`
+    case nameFirst
+    case queryFirst
+    case custom((_ issuerSplittedFromName: String?, _ issuerFromQueryItems: String?) throws -> String?)
+    
+    public func grabIssuer(issuerSplittedFromName: String?, issuerFromQueryItems: String?) throws -> String? {
+        switch self {
+        case .default:
+            /// The issuer parameter is a string value indicating the provider or service this account is associated with, URL-encoded according to RFC 3986.
+            /// If the issuer parameter is absent, issuer information may be taken from the issuer prefix of the label.
+            /// If both issuer parameter and issuer label prefix are present, they should be equal.
+            /// Source: https://github.com/google/google-authenticator/wiki/Key-Uri-Format#issuer
+            switch (issuerSplittedFromName, issuerFromQueryItems) {
+            case (.some(let issuerSplittedFromName), .some(let issuerFromQueryItems)):
+                guard issuerSplittedFromName == issuerFromQueryItems else {
+                    throw OTPError.invalidURL
+                }
+                return issuerSplittedFromName
+            case (.some(let issuerSplittedFromName), .none):
+                return issuerSplittedFromName
+            case (.none, .some(let issuerFromQueryItems)):
+                return issuerFromQueryItems
+            case (.none, .none):
+                return nil
+            }
+        case .nameFirst:
+            return issuerSplittedFromName
+        case .queryFirst:
+            return issuerFromQueryItems
+        case .custom(let factory):
+            return try factory(issuerSplittedFromName, issuerFromQueryItems)
+        }
+    }
+}

--- a/Sources/THOTP/Protocols/PasswordProtocol.swift
+++ b/Sources/THOTP/Protocols/PasswordProtocol.swift
@@ -28,4 +28,5 @@ public protocol PasswordProtocol: Equatable {
     
     init(name: String, issuer: String?, image: URL?, generator: GeneratorProtocol)
     init(url: URL) throws
+    init(url: URL, issuerStrategy: IssuerStrategy) throws
 }

--- a/Tests/THOTPTests/AllTests.swift
+++ b/Tests/THOTPTests/AllTests.swift
@@ -142,7 +142,6 @@ final class AllTests: XCTestCase {
         XCTAssertEqual(password.absoluteURL, URL(string: "otpauth://hotp/test?secret=GEZDGNBV&algorithm=SHA512&digits=6&counter=1"))
     }
     
-    
     func test_Timer_absoluteURL() {
     
     let password = Password(name: "test",
@@ -209,7 +208,7 @@ final class AllTests: XCTestCase {
         }
     }
     
-    func test_Counter_URL_Init_MissingIssuer_In_Name() {
+    func test_Counter_URL_Init_MissingIssuer_In_Name_DefaultIssuerStrategy() {
         do {
             let password = Password(name: "john.doe@email.com",
                                          issuer: "ACME Co",
@@ -223,7 +222,7 @@ final class AllTests: XCTestCase {
         }
     }
     
-    func test_Counter_URL_Init_MissingIssuer_In_Query() {
+    func test_Counter_URL_Init_MissingIssuer_In_Query_DefaultIssuerStrategy() {
         do {
             let password = Password(name: "john.doe@email.com",
                                          issuer: "ACME Co",
@@ -237,12 +236,42 @@ final class AllTests: XCTestCase {
         }
     }
     
-    func test_Counter_URL_Init_UnequalIssuer() {
+    func test_Counter_URL_Init_UnequalIssuer_DefaultIssuerStrategy() {
         do {
             let _ = try Password(url: URL(string: "otpauth://hotp/ACME%20Com:john.doe@email.com?secret=GEZDGNBV&algorithm=SHA512&digits=6&counter=1&issuer=ACME%20Co")!)
             XCTAssert(false)
         } catch {
             XCTAssert(true)
+        }
+    }
+    
+    func test_Counter_URL_Init_NameFirstIssuerStrategy() {
+        do {
+            let password = try Password(url: URL(string: "otpauth://hotp/ACME%20Com:john.doe@email.com?secret=GEZDGNBV&algorithm=SHA512&digits=6&counter=1&issuer=ACME%20Co")!,
+                                        issuerStrategy: .nameFirst)
+            XCTAssertEqual(password.issuer, "ACME Com")
+        } catch {
+            XCTAssert(false)
+        }
+    }
+    
+    func test_Counter_URL_Init_QueryFirstIssuerStrategy() {
+        do {
+            let password = try Password(url: URL(string: "otpauth://hotp/ACME%20Com:john.doe@email.com?secret=GEZDGNBV&algorithm=SHA512&digits=6&counter=1&issuer=ACME%20Co")!,
+                                        issuerStrategy: .queryFirst)
+            XCTAssertEqual(password.issuer, "ACME Co")
+        } catch {
+            XCTAssert(false)
+        }
+    }
+    
+    func test_Counter_URL_Init_CustomIssuerStrategy() {
+        do {
+            let password = try Password(url: URL(string: "otpauth://hotp/ACME%20Com:john.doe@email.com?secret=GEZDGNBV&algorithm=SHA512&digits=6&counter=1&issuer=ACME%20Co")!,
+                                        issuerStrategy: .custom { "\($0!) & \($1!)" } )
+            XCTAssertEqual(password.issuer, "ACME Com & ACME Co")
+        } catch {
+            XCTAssert(false)
         }
     }
     


### PR DESCRIPTION
Please merge to resolve issue #15 